### PR TITLE
feat: allow symbol enumeration without text query

### DIFF
--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -159,13 +159,43 @@ impl SearchDb {
         Ok(())
     }
 
-    /// FTS5 search on symbol names, with optional kind, file, and project filters.
+    /// Search or list symbols.
+    /// - With query (no glob in file): FTS5 full-text search on symbol names (BM25-ranked)
+    /// - Without query OR with glob file pattern: List matching symbols (ordered by file, line)
+    ///
+    /// File filter supports glob patterns with * (e.g. "src/*.py").
+    /// Note: When file contains glob patterns, uses SQL GLOB for filtering (case-sensitive).
     pub fn search_symbols(
+        &self,
+        query: Option<&str>,
+        kind: Option<&str>,
+        file: Option<&str>,
+        project: Option<&str>,
+        limit: u32,
+        offset: u32,
+    ) -> Result<Vec<SymbolEntry>> {
+        // Check if file filter contains glob pattern
+        let file_has_glob = file.map(|f| f.contains('*')).unwrap_or(false);
+
+        match query {
+            // Search mode: use FTS5 with BM25 ranking
+            Some(q) if !q.is_empty() && !file_has_glob => {
+                self.search_symbols_fts(q, kind, file, project, limit, offset)
+            }
+            // List mode: plain SQL query (when no query or file has glob pattern)
+            _ => self.list_symbols(query, kind, file, project, limit, offset),
+        }
+    }
+
+    /// FTS5 search on symbol names (BM25-ranked).
+    fn search_symbols_fts(
         &self,
         query: &str,
         kind: Option<&str>,
         file: Option<&str>,
         project: Option<&str>,
+        limit: u32,
+        offset: u32,
     ) -> Result<Vec<SymbolEntry>> {
         // Build the FTS5 match expression, incorporating filters into the query
         let mut fts_parts = vec![format!("name : {}", fts5_quote(query))];
@@ -175,8 +205,8 @@ impl SearchDb {
         if let Some(f) = file {
             fts_parts.push(format!("file : {}", fts5_quote(f)));
         }
-        if let Some(r) = project {
-            fts_parts.push(format!("project : {}", fts5_quote(r)));
+        if let Some(p) = project {
+            fts_parts.push(format!("project : {}", fts5_quote(p)));
         }
         let fts_query = fts_parts.join(" AND ");
 
@@ -187,10 +217,96 @@ impl SearchDb {
              JOIN symbols s ON s.rowid = f.rowid
              WHERE symbols_fts MATCH ?1
              ORDER BY rank
-             LIMIT 100",
+             LIMIT ?2 OFFSET ?3",
         )?;
 
-        let rows = stmt.query_map([&fts_query], |row| {
+        let rows = stmt.query_map(rusqlite::params![&fts_query, limit, offset], |row| {
+            Ok(SymbolEntry {
+                project: row.get(0)?,
+                file: row.get(1)?,
+                name: row.get(2)?,
+                kind: row.get(3)?,
+                line: [row.get(4)?, row.get(5)?],
+                parent: row.get(6)?,
+                sig: row.get(7)?,
+                alias: row.get(8)?,
+                visibility: row.get(9)?,
+            })
+        })?;
+
+        let mut results = Vec::new();
+        for row in rows {
+            results.push(row?);
+        }
+        Ok(results)
+    }
+
+    /// List symbols matching filters (no FTS, ordered by file and line).
+    /// File filter supports SQLite GLOB patterns: * matches any sequence, ? matches single char.
+    /// Query performs substring match on symbol name when provided.
+    fn list_symbols(
+        &self,
+        query: Option<&str>,
+        kind: Option<&str>,
+        file: Option<&str>,
+        project: Option<&str>,
+        limit: u32,
+        offset: u32,
+    ) -> Result<Vec<SymbolEntry>> {
+        // Build WHERE clause dynamically
+        let mut conditions = Vec::new();
+        let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+
+        if let Some(q) = query
+            && !q.is_empty()
+        {
+            // Simple substring match on name when in list mode with glob file
+            conditions.push("name LIKE ?".to_string());
+            params.push(Box::new(format!("%{}%", q)));
+        }
+        if let Some(k) = kind {
+            conditions.push("kind = ?".to_string());
+            params.push(Box::new(k.to_string()));
+        }
+        if let Some(f) = file {
+            if f.contains('*') {
+                // Use GLOB for pattern matching (supports * wildcard)
+                conditions.push("file GLOB ?".to_string());
+                params.push(Box::new(f.to_string()));
+            } else {
+                conditions.push("file = ?".to_string());
+                params.push(Box::new(f.to_string()));
+            }
+        }
+        if let Some(p) = project {
+            conditions.push("project = ?".to_string());
+            params.push(Box::new(p.to_string()));
+        }
+
+        let where_clause = if conditions.is_empty() {
+            String::new()
+        } else {
+            format!("WHERE {}", conditions.join(" AND "))
+        };
+
+        let sql = format!(
+            "SELECT project, file, name, kind, line_start, line_end,
+                    parent, sig, alias, visibility
+             FROM symbols
+             {}
+             ORDER BY file, line_start
+             LIMIT ? OFFSET ?",
+            where_clause
+        );
+
+        let mut stmt = self.conn.prepare(&sql)?;
+
+        // Build params slice for query
+        let mut param_refs: Vec<&dyn rusqlite::ToSql> = params.iter().map(|p| p.as_ref()).collect();
+        param_refs.push(&limit);
+        param_refs.push(&offset);
+
+        let rows = stmt.query_map(rusqlite::params_from_iter(param_refs), |row| {
             Ok(SymbolEntry {
                 project: row.get(0)?,
                 file: row.get(1)?,
@@ -226,8 +342,8 @@ impl SearchDb {
         if let Some(f) = file {
             fts_parts.push(format!("file : {}", fts5_quote(f)));
         }
-        if let Some(r) = project {
-            fts_parts.push(format!("project : {}", fts5_quote(r)));
+        if let Some(p) = project {
+            fts_parts.push(format!("project : {}", fts5_quote(p)));
         }
         let fts_query = fts_parts.join(" AND ");
 
@@ -269,8 +385,8 @@ impl SearchDb {
         if let Some(l) = lang {
             fts_parts.push(format!("lang : {}", fts5_quote(l)));
         }
-        if let Some(r) = project {
-            fts_parts.push(format!("project : {}", fts5_quote(r)));
+        if let Some(p) = project {
+            fts_parts.push(format!("project : {}", fts5_quote(p)));
         }
         let fts_query = fts_parts.join(" AND ");
 
@@ -664,7 +780,7 @@ impl SearchDb {
         Ok((files, symbols, texts))
     }
 
-    /// List all unique repos (projects) in the database.
+    /// List all unique projects in the database.
     pub fn list_projects(&self) -> Result<Vec<String>> {
         let mut stmt = self
             .conn

--- a/src/watcher/handler.rs
+++ b/src/watcher/handler.rs
@@ -777,7 +777,9 @@ mod tests {
         assert_eq!(projects[0], ""); // Root project has empty string
 
         // Search for the main function
-        let symbols = db_guard.search_symbols("main", None, None, None).unwrap();
+        let symbols = db_guard
+            .search_symbols(Some("main"), None, None, None, 100, 0)
+            .unwrap();
         assert!(
             symbols
                 .iter()
@@ -785,7 +787,9 @@ mod tests {
         );
 
         // Search for greet function
-        let symbols = db_guard.search_symbols("greet", None, None, None).unwrap();
+        let symbols = db_guard
+            .search_symbols(Some("greet"), None, None, None, 100, 0)
+            .unwrap();
         assert!(
             symbols
                 .iter()
@@ -822,14 +826,14 @@ mod tests {
 
         // Root project should have app_main (search without filter, check project field)
         let symbols = db_guard
-            .search_symbols("app_main", None, None, None)
+            .search_symbols(Some("app_main"), None, None, None, 100, 0)
             .unwrap();
         assert_eq!(symbols.len(), 1);
         assert_eq!(symbols[0].project, "");
 
         // Subproject should have utility
         let symbols = db_guard
-            .search_symbols("utility", None, None, Some("libs/utils"))
+            .search_symbols(Some("utility"), None, None, Some("libs/utils"), 100, 0)
             .unwrap();
         assert_eq!(symbols.len(), 1);
         assert_eq!(symbols[0].project, "libs/utils");
@@ -866,18 +870,25 @@ mod tests {
 
         // Each function should be in its respective project (search without filter, verify project)
         let root_syms = db_guard
-            .search_symbols("root_fn", None, None, None)
+            .search_symbols(Some("root_fn"), None, None, None, 100, 0)
             .unwrap();
         assert_eq!(root_syms.len(), 1);
         assert_eq!(root_syms[0].project, "");
 
         let core_syms = db_guard
-            .search_symbols("core_fn", None, None, Some("libs/core"))
+            .search_symbols(Some("core_fn"), None, None, Some("libs/core"), 100, 0)
             .unwrap();
         assert_eq!(core_syms.len(), 1);
 
         let nested_syms = db_guard
-            .search_symbols("nested_fn", None, None, Some("libs/core/nested"))
+            .search_symbols(
+                Some("nested_fn"),
+                None,
+                None,
+                Some("libs/core/nested"),
+                100,
+                0,
+            )
             .unwrap();
         assert_eq!(nested_syms.len(), 1);
     }
@@ -905,7 +916,9 @@ mod tests {
         let db_guard = db.lock().unwrap();
 
         // Search without project filter - should find both
-        let all_symbols = db_guard.search_symbols("fn", None, None, None).unwrap();
+        let all_symbols = db_guard
+            .search_symbols(Some("fn"), None, None, None, 100, 0)
+            .unwrap();
         let root_fn_count = all_symbols.iter().filter(|s| s.name == "root_fn").count();
         let sub_fn_count = all_symbols.iter().filter(|s| s.name == "sub_fn").count();
 
@@ -976,7 +989,9 @@ mod tests {
         let db_guard = db.lock().unwrap();
 
         // Without filter: should find 2 helpers
-        let all = db_guard.search_symbols("helper", None, None, None).unwrap();
+        let all = db_guard
+            .search_symbols(Some("helper"), None, None, None, 100, 0)
+            .unwrap();
         assert_eq!(all.len(), 2);
 
         // One should be root (empty project), one should be sub
@@ -987,7 +1002,7 @@ mod tests {
 
         // With sub filter: should find 1
         let sub_only = db_guard
-            .search_symbols("helper", None, None, Some("sub"))
+            .search_symbols(Some("helper"), None, None, Some("sub"), 100, 0)
             .unwrap();
         assert_eq!(sub_only.len(), 1);
         assert_eq!(sub_only[0].project, "sub");
@@ -1018,7 +1033,7 @@ mod tests {
 
         // Symbol should have correct project
         let symbols = db_guard
-            .search_symbols("deep_fn", None, None, None)
+            .search_symbols(Some("deep_fn"), None, None, None, 100, 0)
             .unwrap();
         assert_eq!(symbols[0].project, "path/to/deep/project");
     }


### PR DESCRIPTION
Closes #15

## Summary
- Make `query` parameter optional in `search_symbols` tool
- Add `limit` and `offset` parameters for pagination
- Support glob patterns (`*`) in file filter (e.g., `src/*.py`)

## Changes
When `query` is omitted, the tool returns all symbols matching the filters (kind, file, project) ordered by file and line number. This enables use cases like:
- "List all classes in this project"
- "Show me all functions in the data module"
- "Find all constants"

## Examples
```python
# List all functions in a project
search_symbols(kind="function", project="myproject")

# List all classes
search_symbols(kind="class")

# List symbols in specific file pattern
search_symbols(file="src/utils/*.py")

# Search with pagination
search_symbols(query="handler", limit=50, offset=100)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)