### PR TITLE
feat: add interactive query REPL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,9 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "blake3"
@@ -200,6 +203,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-repl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ffd4e57297ee7a10fb637964a79fd4bf5c8d22fd4ceaac5d3964d55df9e9e38"
+dependencies = [
+ "clap",
+ "clap_complete",
+ "console",
+ "nu-ansi-term",
+ "reedline",
+ "shlex",
+]
+
+[[package]]
 name = "clap_builder"
 version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,6 +226,20 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c677cd0126f3026d8b093fa29eae5d812fde5c05bc66dbb29d0374eea95113a"
+dependencies = [
+ "clap",
+ "clap_lex",
+ "is_executable",
+ "pathdiff",
+ "shlex",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -236,6 +267,7 @@ dependencies = [
  "anyhow",
  "blake3",
  "clap",
+ "clap-repl",
  "fs2",
  "ignore",
  "notify",
@@ -244,7 +276,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "toml",
  "tracing",
@@ -269,6 +301,19 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width 0.2.2",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "constant_time_eq"
@@ -317,6 +362,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.10.0",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "serde",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,6 +428,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,6 +472,17 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix 1.1.3",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -633,10 +727,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_executable"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baabb8b4867b26294d818bf3f651a454b6901431711abb96e296245888d6e8c4"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -696,6 +808,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -852,6 +970,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -900,6 +1024,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.10.0",
+]
+
+[[package]]
+name = "reedline"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bfa8cb0ad84c396c936d8abb814703d7042a433d2da75a0c7060cbdc89109f3"
+dependencies = [
+ "chrono",
+ "crossterm",
+ "fd-lock",
+ "itertools",
+ "nu-ansi-term",
+ "serde",
+ "strip-ansi-escapes",
+ "strum",
+ "strum_macros",
+ "thiserror 1.0.69",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -967,7 +1111,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1002,6 +1146,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.10.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
@@ -1009,7 +1166,7 @@ dependencies = [
  "bitflags 2.10.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
 ]
 
@@ -1140,6 +1297,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1178,10 +1356,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "syn"
@@ -1203,8 +1409,17 @@ dependencies = [
  "fastrand",
  "getrandom",
  "once_cell",
- "rustix",
+ "rustix 1.1.3",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -1213,7 +1428,18 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1517,6 +1743,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1533,6 +1783,15 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "walkdir"
@@ -1696,11 +1955,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -1714,20 +1982,42 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1737,9 +2027,21 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1749,9 +2051,21 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1761,15 +2075,33 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ exclude = ["npm/", "python/", ".github/", "spec/", "tests/fixtures/"]
 [dependencies]
 # CLI
 clap = { version = "4", features = ["derive"] }
+clap-repl = "0.3"
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,2 +1,3 @@
 pub mod build;
+pub mod query;
 pub mod serve;

--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -1,0 +1,243 @@
+//! Interactive REPL for querying the code index.
+//!
+//! Provides the same API as the MCP server but through an interactive command line.
+
+use std::path::Path;
+use std::sync::{Arc, mpsc};
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use clap_repl::{ClapEditor, ReadCommandOutput};
+use rmcp::handler::server::wrapper::Parameters;
+
+use crate::cli::build::build_index_to_db;
+use crate::mount::MountedEvent;
+use crate::mount::handler::{flush_mount_to_disk, run_event_loop};
+use crate::server::mcp::{
+    CodeIndexServer, GetCalleesParams, GetCallersParams, GetFileSymbolsParams, GetImportsParams,
+    GetSymbolChildrenParams, SearchFilesParams, SearchReferencesParams, SearchSymbolsParams,
+    SearchTextsParams, extract_result_text,
+};
+
+/// REPL commands matching the MCP tools.
+#[derive(Debug, Parser)]
+#[command(name = "")]
+pub enum QueryCommand {
+    /// Search or list symbols
+    SearchSymbols(#[command(flatten)] SearchSymbolsParams),
+    /// Search files by path
+    SearchFiles(#[command(flatten)] SearchFilesParams),
+    /// Search text entries (docstrings, comments)
+    SearchTexts(#[command(flatten)] SearchTextsParams),
+    /// Get all symbols in a file
+    GetFileSymbols(#[command(flatten)] GetFileSymbolsParams),
+    /// Get children of a symbol
+    GetSymbolChildren(#[command(flatten)] GetSymbolChildrenParams),
+    /// Get imports for a file
+    GetImports(#[command(flatten)] GetImportsParams),
+    /// List all indexed projects
+    ListProjects,
+    /// Find callers of a symbol
+    GetCallers(#[command(flatten)] GetCallersParams),
+    /// Find what a symbol calls
+    GetCallees(#[command(flatten)] GetCalleesParams),
+    /// Search references
+    SearchReferences(#[command(flatten)] SearchReferencesParams),
+    /// Flush index to disk
+    FlushIndex,
+    /// Exit the REPL
+    #[command(alias = "quit")]
+    Exit,
+}
+
+/// Run the interactive query REPL or execute a single command.
+///
+/// If `command` is empty, starts the interactive REPL.
+/// Otherwise, executes the command and exits.
+pub fn run(root: &Path, watch: bool, command: Vec<String>) -> Result<()> {
+    // If watch mode: create channel BEFORE building
+    // This way directories are watched during the single walk (no second walk needed)
+    let (tx, rx): (
+        Option<mpsc::Sender<MountedEvent>>,
+        Option<mpsc::Receiver<MountedEvent>>,
+    ) = if watch {
+        let (tx, rx) = mpsc::channel();
+        (Some(tx), Some(rx))
+    } else {
+        (None, None)
+    };
+
+    // Build index with FTS enabled (loads from .codeindex/ if exists, otherwise parses files)
+    let (mount_table, db) =
+        build_index_to_db(root, true, true, tx.clone()).context("failed to build/load index")?;
+
+    // Flush any dirty mounts to disk
+    {
+        let mt = mount_table
+            .lock()
+            .map_err(|e| anyhow::anyhow!("mount table lock poisoned: {e}"))?;
+        for (mount_root, mount) in mt.iter() {
+            if mount.dirty {
+                flush_mount_to_disk(mount_root, &mt, &db)
+                    .with_context(|| format!("failed to flush {}", mount_root.display()))?;
+            }
+        }
+    }
+
+    // Spawn event loop if watching
+    if let (Some(tx), Some(rx)) = (tx, rx) {
+        let mount_table_clone = Arc::clone(&mount_table);
+        let db_clone = Arc::clone(&db);
+
+        std::thread::spawn(move || {
+            if let Err(e) = run_event_loop(rx, tx, mount_table_clone, db_clone) {
+                tracing::error!("event loop error: {}", e);
+            }
+        });
+    }
+
+    // Create the tokio runtime for async tool calls
+    let rt = tokio::runtime::Runtime::new().context("failed to create tokio runtime")?;
+
+    // Create the MCP server (reusing its tool implementations)
+    let server = CodeIndexServer::new(Arc::clone(&db), Arc::clone(&mount_table));
+
+    // Helper to execute a command
+    let execute_command = |cmd: QueryCommand| {
+        rt.block_on(async {
+            let result = match cmd {
+                QueryCommand::SearchSymbols(params) => {
+                    server.search_symbols(Parameters(params)).await
+                }
+                QueryCommand::SearchFiles(params) => server.search_files(Parameters(params)).await,
+                QueryCommand::SearchTexts(params) => server.search_texts(Parameters(params)).await,
+                QueryCommand::GetFileSymbols(params) => {
+                    server.get_file_symbols(Parameters(params)).await
+                }
+                QueryCommand::GetSymbolChildren(params) => {
+                    server.get_symbol_children(Parameters(params)).await
+                }
+                QueryCommand::GetImports(params) => server.get_imports(Parameters(params)).await,
+                QueryCommand::ListProjects => server.list_projects().await,
+                QueryCommand::GetCallers(params) => server.get_callers(Parameters(params)).await,
+                QueryCommand::GetCallees(params) => server.get_callees(Parameters(params)).await,
+                QueryCommand::SearchReferences(params) => {
+                    server.search_references(Parameters(params)).await
+                }
+                QueryCommand::FlushIndex => server.flush_index().await,
+                QueryCommand::Exit => unreachable!(),
+            };
+
+            match result {
+                Ok(r) => println!("{}", extract_result_text(&r)),
+                Err(e) => eprintln!("Error: {}", e.message),
+            }
+        });
+    };
+
+    // Single command mode: parse and execute, then exit
+    if !command.is_empty() {
+        // Prepend empty string for clap (it expects argv[0] to be program name)
+        let mut args = vec!["".to_string()];
+        args.extend(command);
+
+        match QueryCommand::try_parse_from(&args) {
+            Ok(cmd) => {
+                if matches!(cmd, QueryCommand::Exit) {
+                    return Ok(());
+                }
+                execute_command(cmd);
+            }
+            Err(e) => {
+                e.print().ok();
+            }
+        }
+        return Ok(());
+    }
+
+    // Interactive REPL mode
+    println!("codeix query REPL — type 'help' for commands, 'exit' to quit");
+    let mut rl = ClapEditor::<QueryCommand>::builder().build();
+    loop {
+        match rl.read_command() {
+            ReadCommandOutput::Command(cmd) => {
+                // Handle exit command
+                if matches!(cmd, QueryCommand::Exit) {
+                    break;
+                }
+                execute_command(cmd);
+            }
+            ReadCommandOutput::EmptyLine | ReadCommandOutput::CtrlC => continue,
+            ReadCommandOutput::CtrlD => break,
+            ReadCommandOutput::ClapError(e) => {
+                e.print().ok();
+            }
+            ReadCommandOutput::ShlexError => {
+                eprintln!("Error: Invalid input (check quotes)");
+            }
+            ReadCommandOutput::ReedlineError(e) => {
+                eprintln!("Error: {}", e);
+                break;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_query_command_parse() {
+        // Test list-projects (no args)
+        let cmd = QueryCommand::try_parse_from(["", "list-projects"]).unwrap();
+        assert!(matches!(cmd, QueryCommand::ListProjects));
+
+        // Test flush-index (no args)
+        let cmd = QueryCommand::try_parse_from(["", "flush-index"]).unwrap();
+        assert!(matches!(cmd, QueryCommand::FlushIndex));
+
+        // Test search-symbols with query (positional arg)
+        let cmd = QueryCommand::try_parse_from(["", "search-symbols", "foo"]).unwrap();
+        if let QueryCommand::SearchSymbols(params) = cmd {
+            assert_eq!(params.query, Some("foo".to_string()));
+        } else {
+            panic!("Expected SearchSymbols");
+        }
+
+        // Test search-symbols with options
+        let cmd =
+            QueryCommand::try_parse_from(["", "search-symbols", "--kind", "function"]).unwrap();
+        if let QueryCommand::SearchSymbols(params) = cmd {
+            assert_eq!(params.kind, Some("function".to_string()));
+        } else {
+            panic!("Expected SearchSymbols");
+        }
+
+        // Test get-file-symbols with file (positional required arg)
+        let cmd = QueryCommand::try_parse_from(["", "get-file-symbols", "src/main.rs"]).unwrap();
+        if let QueryCommand::GetFileSymbols(params) = cmd {
+            assert_eq!(params.file, "src/main.rs");
+        } else {
+            panic!("Expected GetFileSymbols");
+        }
+
+        // Test get-callers with name (positional required arg)
+        let cmd = QueryCommand::try_parse_from(["", "get-callers", "my_function"]).unwrap();
+        if let QueryCommand::GetCallers(params) = cmd {
+            assert_eq!(params.name, "my_function");
+        } else {
+            panic!("Expected GetCallers");
+        }
+
+        // Test exit command
+        let cmd = QueryCommand::try_parse_from(["", "exit"]).unwrap();
+        assert!(matches!(cmd, QueryCommand::Exit));
+
+        // Test quit alias
+        let cmd = QueryCommand::try_parse_from(["", "quit"]).unwrap();
+        assert!(matches!(cmd, QueryCommand::Exit));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a new `query` subcommand that provides an interactive REPL for querying the code index
- The REPL reuses the same tool implementations as the MCP server, ensuring consistent behavior
- Query is now the default command when running in a TTY (serve remains default when stdin is piped)
- Supports both interactive REPL mode and single-command mode

## Changes

- Add `clap-repl` dependency for REPL functionality with tab completion
- Add `clap::Args` derive to `*Params` structs so they work with both MCP and CLI
- Create `src/cli/query.rs` with `QueryCommand` enum matching all MCP tools
- Update `main.rs` to make `query` default in TTY, `serve` default when piped

## Usage

```bash
# Interactive REPL (default in terminal)
codeix query

# Single command mode
codeix query list-projects
codeix query search-symbols foo --kind function
codeix query -C /other/path get-callers my_function

# See available commands
codeix query help
```

## Supported Commands

All MCP tools are available:
- `search-symbols`, `search-files`, `search-texts`
- `get-file-symbols`, `get-symbol-children`, `get-imports`
- `list-projects`, `get-callers`, `get-callees`
- `search-references`, `flush-index`

## Test plan

- [x] `cargo build` succeeds
- [x] `cargo test` passes (158 tests)
- [x] `cargo clippy` has no warnings
- [x] `codeix query --help` shows usage
- [x] REPL starts when running `codeix` in a terminal
- [x] Single command mode works: `codeix query list-projects`

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)