### PR TITLE
feat(explore): add explore tool with budget-based file capping

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Eight tools, zero setup. The agent queries immediately — no init, no config, n
 
 | Tool | What it does |
 |---|---|
-| `list_projects` | List all indexed projects |
+| `explore` | Explore project structure: metadata, subprojects, files grouped by directory |
 | `search` | Unified full-text search across symbols, files, and texts (FTS5, BM25-ranked) with scope/kind/path/project filters |
 | `get_file_symbols` | List all symbols in a file |
 | `get_symbol_children` | Get children of a class/module |

--- a/site/templates/index.html
+++ b/site/templates/index.html
@@ -1028,6 +1028,11 @@ footer {
 
     <div class="tool-grid">
       <div class="tool-card reveal reveal-delay-2">
+        <div class="tool-card-kind">discovery</div>
+        <div class="tool-card-name">explore</div>
+        <div class="tool-card-desc">Project structure: metadata, subprojects, and files grouped by directory.</div>
+      </div>
+      <div class="tool-card reveal reveal-delay-2">
         <div class="tool-card-kind">search</div>
         <div class="tool-card-name">search</div>
         <div class="tool-card-desc">Unified full-text search across symbols, files, and texts. FTS5, BM25-ranked, with scope/kind/path filters.</div>

--- a/src/utils/manifest.rs
+++ b/src/utils/manifest.rs
@@ -14,8 +14,10 @@ pub struct ProjectMetadata {
     /// Human-readable project name (from first manifest found, or directory name)
     pub name: String,
     /// Project description (from first manifest with description)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     /// List of manifest files found (e.g., ["package.json", "Cargo.toml"])
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub manifest_files: Vec<String>,
 }
 


### PR DESCRIPTION
## Summary

- Adds `explore` tool for project structure discovery with metadata, subprojects, and files grouped by directory
- Uses parent_path grouping with budget-based capping algorithm:
  - If total files <= max_entries (default 200), show all
  - Otherwise CAP = max_entries / num_groups per directory
- Only spends budget on code files (lang IS NOT NULL), non-code summarized as "+N other files"
- Shows all subprojects at any depth

## Test plan

- [x] `./target/release/codeix query --path ../test-repos explore` shows subprojects
- [x] `./target/release/codeix query --path ../test-repos/leveldb explore` shows `third_party/benchmark`, `third_party/googletest`
- [x] `./target/release/codeix query --path ../test-repos/FizzBuzzEnterpriseEdition explore` shows capped files with "+N files" indicators
- [x] All 159 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)