### PR TITLE
refactor: rename get_symbol_children to get_children

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Eight tools, zero setup. The agent queries immediately — no init, no config, n
 | `explore` | Explore project structure: metadata, subprojects, files grouped by directory |
 | `search` | Unified full-text search across symbols, files, and texts (FTS5, BM25-ranked) with scope/kind/path/project filters |
 | `get_file_symbols` | List all symbols in a file |
-| `get_symbol_children` | Get children of a class/module |
+| `get_children` | Get children of a class/module |
 | `get_imports` | List imports for a file |
 | `get_callers` | Find all places that call or reference a symbol |
 | `get_callees` | Find all symbols that a function/method calls |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -363,7 +363,7 @@ $ git commit -m "feat: ..."
 | Tool | Input | Returns |
 |---|---|---|
 | `get_file_symbols` | `file` path | All symbols in that file, ordered by line |
-| `get_symbol_children` | `file`, `parent` name | Direct children of a symbol |
+| `get_children` | `file`, `parent` name | Direct children of a symbol |
 | `get_imports` | `file` path | All imports for that file |
 
 ### Graph tools (call relationships)

--- a/site/templates/index.html
+++ b/site/templates/index.html
@@ -1044,7 +1044,7 @@ footer {
       </div>
       <div class="tool-card reveal reveal-delay-3">
         <div class="tool-card-kind">lookup</div>
-        <div class="tool-card-name">get_symbol_children</div>
+        <div class="tool-card-name">get_children</div>
         <div class="tool-card-desc">Get direct children of a class, struct, or module.</div>
       </div>
       <div class="tool-card reveal reveal-delay-3">

--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -14,8 +14,8 @@ use crate::cli::build::build_index_to_db;
 use crate::mount::MountedEvent;
 use crate::mount::handler::{flush_mount_to_disk, run_event_loop};
 use crate::server::mcp::{
-    CodeIndexServer, ExploreParams, GetCalleesParams, GetCallersParams, GetFileSymbolsParams,
-    GetImportsParams, GetSymbolChildrenParams, SearchParams, extract_result_text,
+    CodeIndexServer, ExploreParams, GetCalleesParams, GetCallersParams, GetChildrenParams,
+    GetFileSymbolsParams, GetImportsParams, SearchParams, extract_result_text,
 };
 
 /// REPL commands matching the MCP tools.
@@ -28,7 +28,7 @@ pub enum QueryCommand {
     /// Get all symbols in a file
     GetFileSymbols(#[command(flatten)] GetFileSymbolsParams),
     /// Get children of a symbol
-    GetSymbolChildren(#[command(flatten)] GetSymbolChildrenParams),
+    GetChildren(#[command(flatten)] GetChildrenParams),
     /// Get imports for a file
     GetImports(#[command(flatten)] GetImportsParams),
     /// Explore project structure (files grouped by directory)
@@ -104,9 +104,7 @@ pub fn run(root: &Path, watch: bool, command: Vec<String>) -> Result<()> {
                 QueryCommand::GetFileSymbols(params) => {
                     server.get_file_symbols(Parameters(params)).await
                 }
-                QueryCommand::GetSymbolChildren(params) => {
-                    server.get_symbol_children(Parameters(params)).await
-                }
+                QueryCommand::GetChildren(params) => server.get_children(Parameters(params)).await,
                 QueryCommand::GetImports(params) => server.get_imports(Parameters(params)).await,
                 QueryCommand::Explore(params) => server.explore(Parameters(params)).await,
                 QueryCommand::GetCallers(params) => server.get_callers(Parameters(params)).await,

--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -459,7 +459,7 @@ impl SearchDb {
     }
 
     /// Get direct children of a symbol in a file.
-    pub fn get_symbol_children(&self, file: &str, parent: &str) -> Result<Vec<SymbolEntry>> {
+    pub fn get_children(&self, file: &str, parent: &str) -> Result<Vec<SymbolEntry>> {
         let mut stmt = self.conn.prepare(
             "SELECT project, file, name, kind, line_start, line_end, parent, tokens, alias, visibility
              FROM symbols

--- a/src/server/mcp.rs
+++ b/src/server/mcp.rs
@@ -62,7 +62,7 @@ pub struct GetFileSymbolsParams {
 }
 
 #[derive(Debug, Deserialize, JsonSchema, Args)]
-pub struct GetSymbolChildrenParams {
+pub struct GetChildrenParams {
     /// File path containing the parent symbol
     pub file: String,
     /// Name of the parent symbol
@@ -297,19 +297,17 @@ impl CodeIndexServer {
     #[tool(
         description = "Get direct children of a symbol (e.g. methods of a class). Returns code snippets by default."
     )]
-    pub async fn get_symbol_children(
+    pub async fn get_children(
         &self,
-        Parameters(params): Parameters<GetSymbolChildrenParams>,
+        Parameters(params): Parameters<GetChildrenParams>,
     ) -> Result<CallToolResult, McpError> {
         let db = self
             .db
             .lock()
             .map_err(|e| McpError::internal_error(format!("db lock poisoned: {e}"), None))?;
         let results = db
-            .get_symbol_children(&params.file, &params.parent)
-            .map_err(|e| {
-                McpError::internal_error(format!("get_symbol_children failed: {e}"), None)
-            })?;
+            .get_children(&params.file, &params.parent)
+            .map_err(|e| McpError::internal_error(format!("get_children failed: {e}"), None))?;
 
         drop(db); // Release lock before file I/O
 
@@ -635,7 +633,7 @@ impl ServerHandler for CodeIndexServer {
                  Filter by scope, kind, path (glob), project. Returns BM25-ranked results with code snippets.\n\n\
                  **Structural navigation:**\n\
                  - `get_file_symbols`: All symbols in a file, ordered by line number.\n\
-                 - `get_symbol_children`: Direct children of a symbol (e.g., methods of a class).\n\
+                 - `get_children`: Direct children of a symbol (e.g., methods of a class).\n\
                  - `get_imports`: Import statements in a file.\n\n\
                  **Reference tracking:**\n\
                  - `get_callers`: Find all places that call/reference a symbol.\n\


### PR DESCRIPTION
Closes #49

## Summary
- Renamed `get_symbol_children` to `get_children` for brevity
- "symbol" is redundant - context makes it clear
- Consistent with other `get_*` tools that don't repeat the noun
- Shorter command for CLI usage

## Changes
- `src/server/db.rs`: Renamed method
- `src/server/mcp.rs`: Renamed method, params struct, and updated error message + docs
- `src/cli/query.rs`: Updated command enum and method call
- `README.md`: Updated tool table
- `docs/architecture.md`: Updated tool table
- `site/templates/index.html`: Updated tool card

No functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)