### PR TITLE
refactor: unify parameters across get_callers/get_callees (#50)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -362,16 +362,26 @@ $ git commit -m "feat: ..."
 
 | Tool | Input | Returns |
 |---|---|---|
-| `get_file_symbols` | `file` path | All symbols in that file, ordered by line |
-| `get_children` | `file`, `parent` name | Direct children of a symbol |
-| `get_imports` | `file` path | All imports for that file |
+| `get_file_symbols` | `file` path, optional pagination | All symbols in that file, ordered by line |
+| `get_children` | `file`, `parent` name, optional pagination | Direct children of a symbol |
+| `get_imports` | `file` path, optional pagination | All imports for that file |
 
 ### Graph tools (call relationships)
 
 | Tool | Input | Returns |
 |---|---|---|
-| `get_callers` | `name`, optional `kind`/`project` filters | All call sites and references to a symbol |
-| `get_callees` | `caller`, optional `kind`/`project` filters | All symbols that a function calls |
+| `get_callers` | `name`, optional `kind`/`project`/pagination/snippets | All call sites and references to a symbol |
+| `get_callees` | `caller`, optional `kind`/`project`/pagination/snippets | All symbols that a function calls |
+
+### Common parameters
+
+All list/search tools support these optional parameters:
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `limit` | 100 | Maximum results to return |
+| `offset` | 0 | Skip N results for pagination |
+| `snippet_lines` | 10 | Code context lines (0=none, -1=all) |
 
 ### Index management
 


### PR DESCRIPTION
Closes #50

## Summary
- Add `limit`/`offset` pagination to `get_callers`, `get_callees`, `get_file_symbols`, `get_children`, `get_imports`
- Add `snippet_lines` support to `get_callers` and `get_callees` for code context
- Add `ReferenceWithSnippet` struct for enriched reference results
- Update global server instructions with common parameters documentation

## Changes

### Parameter unification
All list/search tools now support consistent pagination:

| Tool | limit/offset | snippet_lines |
|------|--------------|---------------|
| `search` | ✅ | ✅ |
| `get_callers` | ✅ (new) | ✅ (new) |
| `get_callees` | ✅ (new) | ✅ (new) |
| `get_file_symbols` | ✅ (new) | ✅ |
| `get_children` | ✅ (new) | ✅ |
| `get_imports` | ✅ (new) | ❌ |

### Global instructions
Documented common parameters in the MCP server's global instructions to avoid repetition:
- `limit` (default 100): Maximum results to return
- `offset` (default 0): Skip N results for pagination
- `snippet_lines` (default 10): Code context lines (0=none, -1=all)
- `kind`: Filter by symbol/reference kind
- `project`: Filter by project path

## Test plan
- [x] All 159 tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)