### PR TITLE
refactor(cli): unify --root option across all commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ```
 codeix                 # start MCP server, watch for changes
 codeix build           # parse source files, write .codeindex
-codeix serve --no-watch  # serve without file watching
+codeix -r ~/project build  # build from a specific directory
 ```
 
 ## Why
@@ -149,7 +149,7 @@ All channels install the same single binary. No runtime dependencies.
 codeix build
 
 # Build from a specific directory (discovers all git repos below)
-codeix build ~/projects
+codeix -r ~/projects build
 
 # Start MCP server (default command, watches for changes)
 codeix
@@ -157,6 +157,9 @@ codeix
 # Or explicitly
 codeix serve
 codeix serve --no-watch
+
+# Serve from a specific directory
+codeix -r ~/projects serve
 ```
 
 ### MCP client configuration

--- a/site/templates/index.html
+++ b/site/templates/index.html
@@ -1018,9 +1018,9 @@ footer {
         <span class="format-title">terminal</span>
       </div>
       <div class="tool-terminal-body">
-        <div><span class="prompt">codeix build</span> <span class="comment">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;# parse source, write .codeindex</span></div>
-        <div><span class="prompt">codeix serve</span> <span class="comment">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;# MCP server + file watcher</span></div>
-        <div><span class="prompt">codeix serve --no-watch</span> <span class="comment">&nbsp;# serve without watching</span></div>
+        <div><span class="prompt">codeix build</span> <span class="comment">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;# parse source, write .codeindex</span></div>
+        <div><span class="prompt">codeix serve</span> <span class="comment">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;# MCP server + file watcher</span></div>
+        <div><span class="prompt">codeix -r ~/project build</span> <span class="comment">&nbsp;&nbsp;# build from a specific dir</span></div>
       </div>
     </div>
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,10 @@ use clap::{Parser, Subcommand};
     about = "Portable, composable code index\n\nhttps://codeix.dev"
 )]
 struct Cli {
+    /// Root directory (defaults to current dir)
+    #[arg(short = 'r', long = "root", global = true, default_value = ".")]
+    root: String,
+
     #[command(subcommand)]
     command: Option<Commands>,
 }
@@ -17,16 +21,9 @@ struct Cli {
 #[derive(Subcommand)]
 enum Commands {
     /// Build the .codeindex/ for discovered projects
-    Build {
-        /// Root directory to scan (defaults to current dir)
-        #[arg(default_value = ".")]
-        path: String,
-    },
+    Build,
     /// Start the MCP server (default when stdin is piped)
     Serve {
-        /// Root directory (defaults to current dir)
-        #[arg(default_value = ".")]
-        path: String,
         /// Disable file watching
         #[arg(long)]
         no_watch: bool,
@@ -35,9 +32,6 @@ enum Commands {
     ///
     /// Run 'codeix query help' to see available commands.
     Query {
-        /// Root directory (defaults to current dir)
-        #[arg(short = 'C', long, default_value = ".")]
-        path: String,
         /// Disable file watching
         #[arg(long)]
         no_watch: bool,
@@ -53,37 +47,30 @@ fn main() -> Result<()> {
         .init();
 
     let cli = Cli::parse();
+    let root = Path::new(&cli.root);
 
     let command = cli.command.unwrap_or_else(|| {
         if std::io::stdin().is_terminal() {
             // Interactive terminal: default to query REPL
             Commands::Query {
-                path: ".".into(),
                 no_watch: false,
                 command: vec![],
             }
         } else {
             // Piped stdin (e.g. MCP client): default to serve
-            Commands::Serve {
-                path: ".".into(),
-                no_watch: false,
-            }
+            Commands::Serve { no_watch: false }
         }
     });
 
     match command {
-        Commands::Build { path } => {
-            codeix::cli::build::run(Path::new(&path))?;
+        Commands::Build => {
+            codeix::cli::build::run(root)?;
         }
-        Commands::Serve { path, no_watch } => {
-            codeix::cli::serve::run(Path::new(&path), !no_watch)?;
+        Commands::Serve { no_watch } => {
+            codeix::cli::serve::run(root, !no_watch)?;
         }
-        Commands::Query {
-            path,
-            no_watch,
-            command,
-        } => {
-            codeix::cli::query::run(Path::new(&path), !no_watch, command)?;
+        Commands::Query { no_watch, command } => {
+            codeix::cli::query::run(root, !no_watch, command)?;
         }
     }
 


### PR DESCRIPTION
Closes #59

## Summary
- Move root directory option from per-subcommand to global `-r/--root`
- Remove inconsistent positional args from `build` and `serve`
- Remove `-C/--path` from `query`

## Before/After

| Before | After |
|--------|-------|
| `codeix build /my/project` | `codeix -r /my/project build` |
| `codeix serve /my/project` | `codeix --root /my/project serve` |
| `codeix query -C /my/project search foo` | `codeix -r /my/project query search foo` |

## Why `-r/--root`?

- `--root` is explicit about what it means (project root)
- `-r` is short and memorable
- Avoids confusion with file paths in individual commands
- More intuitive than git-style `-C` (which stands for... nothing obvious)

## Test plan
- [x] All 161 tests pass
- [x] `codeix --help` shows global `-r/--root` option
- [x] `codeix build --help` shows inherited `-r/--root` option
- [x] `codeix serve --help` shows inherited `-r/--root` option
- [x] `codeix query --help` shows inherited `-r/--root` option

🤖 Generated with [Claude Code](https://claude.com/claude-code)