### PR TITLE
feat(mcp)!: remove redundant get_imports tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Works with Git repos, npm, PyPI, and crates.io.
 
 ## MCP tools
 
-Eight tools, zero setup. The agent queries immediately — no init, no config, no refresh.
+Seven tools, zero setup. The agent queries immediately — no init, no config, no refresh.
 
 | Tool | What it does |
 |---|---|
@@ -71,7 +71,6 @@ Eight tools, zero setup. The agent queries immediately — no init, no config, n
 | `search` | Unified full-text search across symbols, files, and texts (FTS5, BM25-ranked) with scope/kind/path/project filters |
 | `get_file_symbols` | List all symbols in a file |
 | `get_children` | Get children of a class/module |
-| `get_imports` | List imports for a file |
 | `get_callers` | Find all places that call or reference a symbol |
 | `get_callees` | Find all symbols that a function/method calls |
 | `flush_index` | Flush pending index changes to disk |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -364,7 +364,6 @@ $ git commit -m "feat: ..."
 |---|---|---|
 | `get_file_symbols` | `file` path, optional pagination | All symbols in that file, ordered by line |
 | `get_children` | `file`, `parent` name, optional pagination | Direct children of a symbol |
-| `get_imports` | `file` path, optional pagination | All imports for that file |
 
 ### Graph tools (call relationships)
 

--- a/site/templates/index.html
+++ b/site/templates/index.html
@@ -1047,11 +1047,6 @@ footer {
         <div class="tool-card-name">get_children</div>
         <div class="tool-card-desc">Get direct children of a class, struct, or module.</div>
       </div>
-      <div class="tool-card reveal reveal-delay-3">
-        <div class="tool-card-kind">lookup</div>
-        <div class="tool-card-name">get_imports</div>
-        <div class="tool-card-desc">List all import statements for a file.</div>
-      </div>
       <div class="tool-card reveal reveal-delay-4">
         <div class="tool-card-kind">graph</div>
         <div class="tool-card-name">get_callers</div>

--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -15,7 +15,7 @@ use crate::mount::MountedEvent;
 use crate::mount::handler::{flush_mount_to_disk, run_event_loop};
 use crate::server::mcp::{
     CodeIndexServer, ExploreParams, GetCalleesParams, GetCallersParams, GetChildrenParams,
-    GetFileSymbolsParams, GetImportsParams, SearchParams, extract_result_text,
+    GetFileSymbolsParams, SearchParams, extract_result_text,
 };
 
 /// REPL commands matching the MCP tools.
@@ -29,8 +29,6 @@ pub enum QueryCommand {
     GetFileSymbols(#[command(flatten)] GetFileSymbolsParams),
     /// Get children of a symbol
     GetChildren(#[command(flatten)] GetChildrenParams),
-    /// Get imports for a file
-    GetImports(#[command(flatten)] GetImportsParams),
     /// Explore project structure (files grouped by directory)
     Explore(#[command(flatten)] ExploreParams),
     /// Find callers of a symbol
@@ -105,7 +103,6 @@ pub fn run(root: &Path, watch: bool, command: Vec<String>) -> Result<()> {
                     server.get_file_symbols(Parameters(params)).await
                 }
                 QueryCommand::GetChildren(params) => server.get_children(Parameters(params)).await,
-                QueryCommand::GetImports(params) => server.get_imports(Parameters(params)).await,
                 QueryCommand::Explore(params) => server.explore(Parameters(params)).await,
                 QueryCommand::GetCallers(params) => server.get_callers(Parameters(params)).await,
                 QueryCommand::GetCallees(params) => server.get_callees(Parameters(params)).await,

--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -501,37 +501,6 @@ impl SearchDb {
         Ok(results)
     }
 
-    /// Get all imports for a file (symbols with kind "import").
-    pub fn get_imports(&self, file: &str, limit: u32, offset: u32) -> Result<Vec<SymbolEntry>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT project, file, name, kind, line_start, line_end, parent, tokens, alias, visibility
-             FROM symbols
-             WHERE file = ?1 AND kind = 'import'
-             ORDER BY line_start
-             LIMIT ?2 OFFSET ?3",
-        )?;
-
-        let rows = stmt.query_map(rusqlite::params![file, limit, offset], |row| {
-            Ok(SymbolEntry {
-                project: row.get(0)?,
-                file: row.get(1)?,
-                name: row.get(2)?,
-                kind: row.get(3)?,
-                line: [row.get(4)?, row.get(5)?],
-                parent: row.get(6)?,
-                tokens: row.get(7)?,
-                alias: row.get(8)?,
-                visibility: row.get(9)?,
-            })
-        })?;
-
-        let mut results = Vec::new();
-        for row in rows {
-            results.push(row?);
-        }
-        Ok(results)
-    }
-
     /// Get all references TO a symbol (who calls/uses this symbol).
     /// Returns references sorted by file, then line.
     pub fn get_callers(

--- a/src/utils/format.rs
+++ b/src/utils/format.rs
@@ -190,27 +190,6 @@ fn format_symbols_text(symbols: &[SymbolWithSnippet]) -> String {
     out
 }
 
-/// Format imports (simplified symbols).
-pub fn format_imports(
-    imports: &[SymbolEntry],
-    format: OutputFormat,
-) -> Result<String, serde_json::Error> {
-    match format {
-        OutputFormat::Json => serde_json::to_string_pretty(imports),
-        OutputFormat::Text => Ok(format_imports_text(imports)),
-    }
-}
-
-fn format_imports_text(imports: &[SymbolEntry]) -> String {
-    let mut out = String::new();
-    for imp in imports {
-        // file[line] import name
-        let location = format_location(&imp.file, imp.line);
-        let _ = writeln!(out, "{} import {}", location, imp.name);
-    }
-    out
-}
-
 /// Response wrapper for ReferenceEntry with optional snippet.
 #[derive(Debug, Serialize)]
 pub struct ReferenceWithSnippet {


### PR DESCRIPTION
## Summary

Remove the `get_imports` MCP tool as it is redundant with existing alternatives:

- `get_file_symbols(file)` - returns all symbols including imports
- `search(path=file, kind="import")` - returns imports with FTS flexibility

## Changes

- Removed `GetImportsParams` struct from `mcp.rs`
- Removed `get_imports` method from `CodeIndexServer` (MCP tool)
- Removed `get_imports` method from `SearchDb` (database layer)
- Removed `GetImports` variant from `QueryCommand` enum (CLI/REPL)
- Removed `format_imports` function from `format.rs`
- Updated documentation (README.md, architecture.md)
- Updated website template (site/templates/index.html)

## Breaking Change

This is a breaking change that removes the `get_imports` MCP tool from the API. Users should migrate to:
- `get_file_symbols` to see all symbols (including imports) in a file
- `search` with `kind="import"` filter for FTS-powered import search

Closes #64

## Test Plan

- [x] All 196 existing tests pass
- [x] Verified `search --kind import` works as expected alternative
- [x] Verified `get-file-symbols` still shows imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)