### PR TITLE
fix(watcher): emit ProjectRemoved event when subproject deleted

### DIFF
--- a/src/server/db.rs
+++ b/src/server/db.rs
@@ -683,6 +683,32 @@ impl SearchDb {
         Ok(())
     }
 
+    /// Remove all data for a project (files, symbols, texts, refs).
+    /// Does not rebuild FTS indexes - caller should call rebuild_fts() after batch operations.
+    pub fn remove_project(&self, project: &str) -> Result<()> {
+        let tx = self.conn.unchecked_transaction()?;
+
+        tx.execute(
+            "DELETE FROM files WHERE project = ?1",
+            rusqlite::params![project],
+        )?;
+        tx.execute(
+            "DELETE FROM symbols WHERE project = ?1",
+            rusqlite::params![project],
+        )?;
+        tx.execute(
+            "DELETE FROM texts WHERE project = ?1",
+            rusqlite::params![project],
+        )?;
+        tx.execute(
+            "DELETE FROM refs WHERE project = ?1",
+            rusqlite::params![project],
+        )?;
+
+        tx.commit()?;
+        Ok(())
+    }
+
     /// Upsert a single file and its symbols/texts/references.
     /// Removes old data for this path first, then inserts new data.
     /// Does not rebuild FTS indexes - caller should call rebuild_fts() after batch operations.


### PR DESCRIPTION
## Summary

Fixes the issue where subprojects are not cleaned up when their directory is deleted while in `--watch` mode.

- Added `ProjectRemoved` variant to `FsEvent` enum to signal when a project is removed
- Updated `on_dir_removed()` to detect `.git` directory deletion and emit `ProjectRemoved`
- Added `remove_project()` method to `SearchDb` to delete all data for a project (files, symbols, texts, refs)
- Added `unmount_path()` to `MountTable` for safely unmounting deleted directories
- Handled `ProjectRemoved` event in the event handler to unmount and clean up DB

## Test plan

- [x] Added unit tests for `ProjectRemoved` event emission (`test_on_dir_removed_emits_project_removed`)
- [x] Added unit test for regular directory removal (`test_on_dir_removed_regular_dir_no_event`)
- [x] Added integration test for project removal cleanup (`test_project_removal_cleans_up_db`)
- [x] All 199 tests pass

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)