### PR TITLE
feat(bench): record Claude version and model in results

### DIFF
--- a/scripts/bench/__main__.py
+++ b/scripts/bench/__main__.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from . import index_speed, search_quality, search_value
 from .ab import parse_judge_winner
-from .common import RESPONSE_CACHE_DIR, log, log_success
+from .common import RESPONSE_CACHE_DIR, get_claude_version, log, log_success
 
 
 def export_results(
@@ -106,9 +106,25 @@ def export_results(
             },
         })
 
+    # Extract model from first result that has it
+    claude_model = None
+    for r in results:
+        # Check response_a and response_b for model info
+        for key in ["response_a", "response_b"]:
+            resp = r.get(key, {})
+            if isinstance(resp, dict) and resp.get("model"):
+                claude_model = resp["model"]
+                break
+        if claude_model:
+            break
+
     report = {
         "created": datetime.now().isoformat(),
         "benchmark": config_name,
+        "metadata": {
+            "claude_code_version": get_claude_version(),
+            "claude_model": claude_model,
+        },
         "summary": summary,
         "tests": tests,
     }

--- a/scripts/bench/common.py
+++ b/scripts/bench/common.py
@@ -313,6 +313,7 @@ RUNTIME_ERROR_PATTERNS = [
     "read timeout",
     "connect timeout",
     "request timeout",
+    "cannot be launched inside another Claude Code session",
 ]
 
 


### PR DESCRIPTION
## Summary

Closes #87

- Adds `metadata` section to benchmark JSON export with:
  - `claude_code_version`: Output of `claude --version` (e.g., "2.1.50 (Claude Code)")
  - `claude_model`: Model name extracted from `modelUsage` in Claude response (e.g., "claude-opus-4-6")

## Example output

```json
{
  "created": "2026-02-21T16:57:17.180051",
  "benchmark": "search-value",
  "metadata": {
    "claude_code_version": "2.1.50 (Claude Code)",
    "claude_model": "claude-opus-4-6"
  },
  "summary": { ... },
  "tests": [ ... ]
}
```

## Test plan

- [x] Verified `get_claude_version()` returns correct output
- [x] Tested model extraction from stream-json response
- [x] Ran benchmark with `--export` flag to verify metadata in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)