### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 **[codeix.dev](https://codeix.dev)** · Fast semantic code search for AI agents — find symbols, references, and callers across any codebase.
 
+<a href="https://glama.ai/mcp/servers/@montanetech/codeix">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@montanetech/codeix/badge" alt="codeix MCP server" />
+</a>
+
 ```
 codeix                 # start MCP server, watch for changes
 codeix build           # parse source files, write .codeindex


### PR DESCRIPTION
This PR adds a badge for the [codeix](https://glama.ai/mcp/servers/@montanetech/codeix) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@montanetech/codeix">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@montanetech/codeix/badge" alt="codeix MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.